### PR TITLE
Updated vcpkg-configuration.json to latest version a.o. 

### DIFF
--- a/.ci/vcpkg-configuration.json
+++ b/.ci/vcpkg-configuration.json
@@ -7,11 +7,11 @@
         }
     ],
     "requires": {
-        "arm:tools/open-cmsis-pack/cmsis-toolbox": "^2.6.0",
-        "arm:tools/arm/mdk-toolbox":" ^1.0.0",
-        "arm:tools/kitware/cmake": "^3.28.4",
-        "arm:tools/ninja-build/ninja": "^1.12.0",
-        "arm:compilers/arm/armclang": "^6.22.0",
-        "arm:compilers/arm/arm-none-eabi-gcc": "^13.3.1"
+        "arm:tools/open-cmsis-pack/cmsis-toolbox": "^2.9.0",
+        "arm:tools/arm/mdk-toolbox":" ^1.1.0",
+        "arm:tools/kitware/cmake": "^3.31.5",
+        "arm:tools/ninja-build/ninja": "^1.12.1",
+        "arm:compilers/arm/armclang": "^6.24.0",
+        "arm:compilers/arm/arm-none-eabi-gcc": "^14.2.1"
     }
 }

--- a/.github/workflows/Test-Examples.yml
+++ b/.github/workflows/Test-Examples.yml
@@ -63,9 +63,8 @@ jobs:
         run: |
           mkdir -p ./CI/Examples/Blinky
           # Enable the option to copy hiden files and folders
-          shopt -s dotglob
-          cp -rf ./BSP/Examples/Blinky/* ./CI/Examples/Blinky/
-          shopt -u dotglob  # disable it again
+          cp -a ./BSP/Examples/Blinky/. ./CI/Examples/Blinky/
+
 
       - name: Build Blinky AC6
         if: always()

--- a/.github/workflows/Test-Examples.yml
+++ b/.github/workflows/Test-Examples.yml
@@ -62,13 +62,16 @@ jobs:
         working-directory: ./
         run: |
           mkdir -p ./CI/Examples/Blinky
+          # Enable the option to copy hiden files and folders
+          shopt -s dotglob
           cp -rf ./BSP/Examples/Blinky/* ./CI/Examples/Blinky/
+          shopt -u dotglob  # disable it again
 
       - name: Build Blinky AC6
         if: always()
         working-directory: ./CI/Examples/Blinky
         run: |
-          cbuild ./Blinky.csolution.yml --packs --update-rte --packs --toolchain AC6 --rebuild
+          cbuild ./Blinky.csolution.yml --packs --toolchain AC6 --rebuild
 
       - name: Upload Artifact of the Blinky AC6 build
         if: always()

--- a/.github/workflows/Test-Examples.yml
+++ b/.github/workflows/Test-Examples.yml
@@ -62,7 +62,6 @@ jobs:
         working-directory: ./
         run: |
           mkdir -p ./CI/Examples/Blinky
-          # Enable the option to copy hiden files and folders
           cp -a ./BSP/Examples/Blinky/. ./CI/Examples/Blinky/
 
 

--- a/Keil.STM32H745I-DISCO_BSP.pdsc
+++ b/Keil.STM32H745I-DISCO_BSP.pdsc
@@ -19,6 +19,8 @@
       - specify thread names using thread attributes
       - rename thread IDs
       - modify app_main_thread (replace loop forever)
+      - Added dbgconf files for the Blinky example.
+	  
     </release>
   </releases>
 


### PR DESCRIPTION
Modified action: Copy Blinky example to CI/Examples/ folder. Copy folder starting with a dot.
Corrected cbuild commandline.